### PR TITLE
Avoiding button outline border from appearing in the lives

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,6 +30,7 @@ button {
   border: 0;
   padding-left: 0px;
   padding-right: 0px;
+  outline: 0;
 }
 
 .imageContainer {


### PR DESCRIPTION
This update should avoid the outline border that appears when you click on the buttons avoiding it from appearing in the lives.

![issue](https://user-images.githubusercontent.com/36212954/123525400-40914e80-d6c8-11eb-86d8-330fc489f701.PNG)
